### PR TITLE
Improve args for `paginate`

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,21 +128,13 @@ defmodule MyApp.PaginationPlanner do
 end
 ```
 
-The `Chunkr.PaginationPlanner.paginate_by/2`  macro sets up a named pagination strategy
-and automatically implements the necessary supporting functions for that strategy at compile time.
+The `paginate_by`  macro sets up a named pagination strategy and implements the underlying
+functions to support that strategy. Each nested call to `sort` establishes a field to sort
+by when using this strategy. Results will be ordered by the first specified `sort` clause,
+then by each subsequent clause in the order specified.
+**The final sort field is the ultimate tie-breaker and _must_ be unique.**
 
-Each call to `sort` establishes a field to sort by when using this strategy. Results
-will be ordered by the first specified `sort` clause, with each subsequent clause acting
-as a tie-breaker. The final sort field _must_ be unique.
-
-Setting up these pagination strategies enables you to call the paginate function—e.g.
-`paginate(some_query, :user_created_at, :desc, opts)` (using the sort direction of the first
-`sort` clause). However, you'll also be able to call
-`paginate(some_query, :user_created_at, :asc, opts)` and Chunkr will automatically invert all
-of the sort orders for you. You always call `paginate()` with the strategy name and the sort
-order of the first field, and the rest of the sort orders will flip as needed.
-
-See more docs in the `Chunkr.PaginationPlanner` module.
+See the `Chunkr.PaginationPlanner` module for more.
 
 ### 2. Use Chunkr in your Repo module:
 
@@ -156,22 +148,22 @@ defmodule MyApp.Repo do
 end
 ```
 
-This adds the convenience functions `paginate/4` and `paginate!/4` to your Repo.
+This adds the convenience functions `paginate/3` and `paginate!/3` to your Repo.
 
 ### 3. Paginate your queries!
 
 ```elixir
-# Provide a query implementing all named bindings referenced in your previously-established strategy
-iex> query = from u in User, as: :user, join: ap in assoc(u, :account_profile), as: :profile
+# Provide a query implementing all named bindings referenced in your named pagination strategy
+iex> query = from u in User, as: :user
 
-# Fetch the first page of results using that strategy
-iex> first_page = MyApp.Repo.paginate!(query, :username, :asc, first: 25)
+# Fetch the first page of results using your named strategy
+iex> first_page = MyApp.Repo.paginate!(query, by: :username, first: 25)
 
 # Extract records
 iex> records = Chunkr.Page.records(first_page)
 
 # Fetch subsequent pages…
-iex> next_page = MyApp.Repo.paginate!(query, :username, :asc, first: 25, after: first_page.end_cursor)
+iex> next_page = MyApp.Repo.paginate!(query, by: :username, first: 25, after: first_page.end_cursor)
 ```
 
 See further documentation at `Chunkr.Pagination` and `Chunkr.Page`.

--- a/lib/chunkr.ex
+++ b/lib/chunkr.ex
@@ -7,14 +7,14 @@ defmodule Chunkr do
   @doc false
   defmacro __using__(config) do
     quote do
-      def paginate!(queryable, strategy, sort_dir, opts) do
+      def paginate!(queryable, opts) do
         default_opts = unquote(config) ++ [{:repo, __MODULE__} | unquote(@default_opts)]
-        Chunkr.Pagination.paginate!(queryable, strategy, sort_dir, opts ++ default_opts)
+        Chunkr.Pagination.paginate!(queryable, opts ++ default_opts)
       end
 
-      def paginate(queryable, strategy, sort_dir, opts) do
+      def paginate(queryable, opts) do
         default_opts = unquote(config) ++ [{:repo, __MODULE__} | unquote(@default_opts)]
-        Chunkr.Pagination.paginate(queryable, strategy, sort_dir, opts ++ default_opts)
+        Chunkr.Pagination.paginate(queryable, opts ++ default_opts)
       end
     end
   end

--- a/test/chunkr/chunkr_test.exs
+++ b/test/chunkr/chunkr_test.exs
@@ -16,28 +16,35 @@ defmodule ChunkrTest do
     {@count, _records} = TestRepo.insert_all(User, Enum.take(user_attrs(), @count))
     query = from(u in User, as: :user)
     expected_results = TestRepo.all(from(u in User, order_by: [asc: u.id]))
-    verify_pagination(TestRepo, query, :single_field, :asc, expected_results, @count)
+    verify_pagination(TestRepo, query, [by: :single_field], expected_results, @count)
   end
 
   test "inverting a single field sort" do
     {@count, _records} = TestRepo.insert_all(User, Enum.take(user_attrs(), @count))
     query = from(u in User, as: :user)
     expected_results = TestRepo.all(from(u in User, order_by: [desc: u.id]))
-    verify_pagination(TestRepo, query, :single_field, :desc, expected_results, @count)
+
+    verify_pagination(
+      TestRepo,
+      query,
+      [by: :single_field, inverted: true],
+      expected_results,
+      @count
+    )
   end
 
   test "paginating by two fields" do
     {@count, _records} = TestRepo.insert_all(User, Enum.take(user_attrs(), @count))
     query = from(u in User, as: :user)
     expected = TestRepo.all(from u in User, order_by: [asc_nulls_last: u.last_name, desc: u.id])
-    verify_pagination(TestRepo, query, :two_fields, :asc, expected, @count)
+    verify_pagination(TestRepo, query, [by: :two_fields], expected, @count)
   end
 
   test "inverting a two field sort" do
     {@count, _records} = TestRepo.insert_all(User, Enum.take(user_attrs(), @count))
     query = from(u in User, as: :user)
     expected = TestRepo.all(from u in User, order_by: [desc_nulls_first: u.last_name, asc: u.id])
-    verify_pagination(TestRepo, query, :two_fields, :desc, expected, @count)
+    verify_pagination(TestRepo, query, [by: :two_fields, inverted: true], expected, @count)
   end
 
   test "paginating by three fields" do
@@ -55,7 +62,7 @@ defmodule ChunkrTest do
         )
       )
 
-    verify_pagination(TestRepo, query, :three_fields, :asc, expected_results, @count)
+    verify_pagination(TestRepo, query, [by: :three_fields], expected_results, @count)
   end
 
   test "inverting a three field sort" do
@@ -73,7 +80,13 @@ defmodule ChunkrTest do
         )
       )
 
-    verify_pagination(TestRepo, query, :three_fields, :desc, expected_results, @count)
+    verify_pagination(
+      TestRepo,
+      query,
+      [by: :three_fields, inverted: true],
+      expected_results,
+      @count
+    )
   end
 
   test "paginating by four fields" do
@@ -92,7 +105,7 @@ defmodule ChunkrTest do
         )
       )
 
-    verify_pagination(TestRepo, query, :four_fields, :desc, expected_results, @count)
+    verify_pagination(TestRepo, query, [by: :four_fields], expected_results, @count)
   end
 
   test "inverting a four field sort" do
@@ -111,7 +124,13 @@ defmodule ChunkrTest do
         )
       )
 
-    verify_pagination(TestRepo, query, :four_fields, :asc, expected_results, @count)
+    verify_pagination(
+      TestRepo,
+      query,
+      [by: :four_fields, inverted: true],
+      expected_results,
+      @count
+    )
   end
 
   test "paginating by UUID" do
@@ -121,7 +140,7 @@ defmodule ChunkrTest do
     expected_results =
       TestRepo.all(from u in User, order_by: [asc_nulls_last: u.last_name, desc: u.public_id])
 
-    verify_pagination(TestRepo, query, :uuid, :asc, expected_results, @count)
+    verify_pagination(TestRepo, query, [by: :uuid], expected_results, @count)
   end
 
   test "paginating with a subquery" do
@@ -137,7 +156,7 @@ defmodule ChunkrTest do
     expected_count = TestRepo.aggregate(from(u in User, where: not is_nil(u.last_name)), :count)
     expected_results = TestRepo.all(from u in query, order_by: [desc: u.last_name, asc: u.id])
 
-    verify_pagination(TestRepo, query, :subquery, :desc, expected_results, expected_count)
+    verify_pagination(TestRepo, query, [by: :subquery], expected_results, expected_count)
   end
 
   test "sorting via a computed value" do
@@ -166,7 +185,7 @@ defmodule ChunkrTest do
           ]
       )
 
-    verify_pagination(TestRepo, query, :computed_value, :desc, expected_results, @count)
+    verify_pagination(TestRepo, query, [by: :computed_value], expected_results, @count)
   end
 
   test "sorting by a potentially-missing association" do
@@ -196,14 +215,7 @@ defmodule ChunkrTest do
           preload: [user: u]
       )
 
-    verify_pagination(
-      TestRepo,
-      query,
-      :by_possibly_null_association,
-      :asc,
-      expected_results,
-      @count
-    )
+    verify_pagination(TestRepo, query, [by: :possibly_null_assoc], expected_results, @count)
   end
 
   #

--- a/test/support/test_pagination_planner.ex
+++ b/test/support/test_pagination_planner.ex
@@ -45,7 +45,7 @@ defmodule Chunkr.TestPaginationPlanner do
   #
   # The essential thing we're looking for here is that phone numbers without an
   # associated user aren't inadvertently dropped from the paginated resut set.
-  paginate_by :by_possibly_null_association do
+  paginate_by :possibly_null_assoc do
     sort :asc, fragment("coalesce(?, ?)", as(:user).first_name, "~~~~~")
     sort :asc, as(:phone).id
   end


### PR DESCRIPTION
* Pass strategy using explicit `:by` opt. This should be more flexible but it also adds a bit of clarity about what the argument represents (i.e. the named pagination strategy).
* Don’t pass `:asc` or `:desc`. This was meant to align with the sort direction of the first field being sorted by; if it matched then we used the sort order provided; if it didn’t match, we inverted all of the sort directions. However, this was hard to read and reason about. We now allow an optional `inverted: true` opt to be passed. If `true` we invert all of the specified sort directions for the named strategy. If not `true`, we leave the sort directions as is.